### PR TITLE
fix: run post hook on provided transaction handler

### DIFF
--- a/src/service-api.ts
+++ b/src/service-api.ts
@@ -50,7 +50,7 @@ const basePlugin: FastifyPluginAsync<GraaspPluginInvitationsOptions> = async (fa
   const createCreateTaskName = mTM.getCreateTaskName();
   runner.setTaskPostHookHandler(
     createCreateTaskName,
-    async (member: Member, _actor, { handler }) => {
+    async (member: Member, _actor, { handler, log }) => {
       // replace invitations to memberships
       const invitations = await dbService.getForMember(member.email, handler);
       if (invitations.length) {
@@ -60,8 +60,9 @@ const basePlugin: FastifyPluginAsync<GraaspPluginInvitationsOptions> = async (fa
             memberId: member.id,
           }),
         );
-        // don't need to wait
-        runner.runMultiple(tasks);
+        // don't need to await
+        // reuse handler of transaction (avoid creating additional connections)
+        tasks.forEach(t =>t.run(handler, log));
       }
     },
   );

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -53,9 +53,7 @@ describe('Invitation Plugin', () => {
       expect(await response.json()).toEqual(FIXTURES_INVITATIONS);
 
       // check email got sent
-      setTimeout(() => {
-        expect(mockSendMail).toHaveBeenCalledTimes(FIXTURES_INVITATIONS.length);
-      }, 2000);
+      expect(mockSendMail).toHaveBeenCalledTimes(FIXTURES_INVITATIONS.length);
     });
 
     it('throw if id is invalid', async () => {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,9 +1,10 @@
 import { StatusCodes } from 'http-status-codes';
 import { v4 } from 'uuid';
 
-import { PermissionLevel } from '@graasp/sdk';
+import { ItemMembership, PermissionLevel } from '@graasp/sdk';
 
 import { GraaspInvitationsError } from '../src/errors';
+import Invitation from '../src/interfaces/invitation';
 
 export const GRAASP_ACTOR = {
   name: 'graasp',
@@ -20,14 +21,15 @@ export const buildInvitation = ({
   permission?: PermissionLevel;
   name?: string;
   itemPath: string;
-}) => ({
+}): Invitation => ({
   id: v4(),
   itemPath,
+  creator: 'fake-creator',
   name: name ?? 'fake-name',
   email: email ?? 'fake-email@mail.com',
   permission: permission ?? PermissionLevel.Read,
-  createdAt: Date.now(),
-  updatedAt: Date.now(),
+  createdAt: Date.now().toString(),
+  updatedAt: Date.now().toString(),
 });
 
 const itemId = v4();
@@ -40,6 +42,15 @@ export const FIXTURE_MEMBER = {
   name: 'anna',
   email: 'anna@mail.com',
   id: 'anna-id',
+};
+export const FIXTURE_MEMBERSHIP: ItemMembership = {
+  id: 'mock-membership-id',
+  memberId: 'anna',
+  itemPath: 'mock-item-path',
+  permission: PermissionLevel.Read,
+  creator: 'mock-creator',
+  createdAt: 'mock-created-at',
+  updatedAt: 'mock-updated-at'
 };
 export const FIXTURES_INVITATIONS = [
   buildInvitation({ itemPath, ...FIXTURE_MEMBER }),

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -24,12 +24,12 @@ export const buildInvitation = ({
 }): Invitation => ({
   id: v4(),
   itemPath,
-  creator: 'fake-creator',
+  creator: '12345678-1234-4567-abcd-123456789012',
   name: name ?? 'fake-name',
   email: email ?? 'fake-email@mail.com',
   permission: permission ?? PermissionLevel.Read,
-  createdAt: Date.now().toString(),
-  updatedAt: Date.now().toString(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
 });
 
 const itemId = v4();
@@ -50,7 +50,7 @@ export const FIXTURE_MEMBERSHIP: ItemMembership = {
   permission: PermissionLevel.Read,
   creator: 'mock-creator',
   createdAt: 'mock-created-at',
-  updatedAt: 'mock-updated-at'
+  updatedAt: 'mock-updated-at',
 };
 export const FIXTURES_INVITATIONS = [
   buildInvitation({ itemPath, ...FIXTURE_MEMBER }),

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -41,13 +41,13 @@ describe('Hooks', () => {
       const filteredInvitations = invitations.filter(
         (invitation) => invitation.email === member.email,
       );
-      const mock = mockCreateMembershipFromInvitationTask(runner, invitations);
+      const mocks = mockCreateMembershipFromInvitationTask(runner, invitations);
       mockGetForMember(filteredInvitations);
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === memberTaskManager.getCreateTaskName()) {
           await fn(member, actor, { handler, log });
-          expect(mock).toHaveBeenCalledTimes(filteredInvitations.length);
+          mocks.forEach(mock => expect(mock).toHaveBeenCalledTimes(filteredInvitations.length));
         }
       });
 
@@ -59,13 +59,13 @@ describe('Hooks', () => {
       const filteredInvitations = invitations.filter(
         (invitation) => invitation.email === member.email,
       );
-      const mock = mockCreateMembershipFromInvitationTask(runner, invitations);
+      const mocks = mockCreateMembershipFromInvitationTask(runner, invitations);
       mockGetForMember(filteredInvitations);
 
       jest.spyOn(runner, 'setTaskPostHookHandler').mockImplementation(async (name, fn) => {
         if (name === memberTaskManager.getCreateTaskName()) {
           await fn(member, actor, { handler, log });
-          expect(mock).toHaveBeenCalledTimes(filteredInvitations.length);
+          mocks.forEach(mock => expect(mock).toHaveBeenCalledTimes(filteredInvitations.length));
         }
       });
 

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,12 +1,21 @@
+import { ItemMembershipService } from '@graasp/sdk';
 import { Task as MockTask } from 'graasp-test';
 
 import { InvitationService } from '../src/db-service';
 import InvitationTaskManager from '../src/task-manager';
+import CreateMembershipFromInvitationTask from '../src/tasks/create-membership-from-invitation-task';
+import { FIXTURES_INVITATIONS, FIXTURE_MEMBERSHIP } from './fixtures';
 
 export const mockCreateMembershipFromInvitationTask = (runner, data) => {
-  return jest
-    .spyOn(InvitationTaskManager.prototype, 'createCreateMembershipFromInvitationTask')
-    .mockImplementation(() => data);
+  const mockCreateMembership = jest
+    .spyOn(InvitationService.prototype, 'createMembership')
+    .mockImplementation((partialMember, handler) => Promise.resolve(FIXTURE_MEMBERSHIP));
+
+  const mockDelete = jest
+    .spyOn(InvitationService.prototype, 'delete')
+    .mockImplementation((id, handler) => Promise.resolve(FIXTURES_INVITATIONS[0]));
+
+  return [mockCreateMembership, mockDelete];
 };
 
 export const mockGetForMember = (data) => {


### PR DESCRIPTION
- Runs the invitations dispatch in the create member task post hook handler on the provided transaction handler (avoid creating many db connections while blocking the task transaction)
- Fixes the tests accordingly with correct types
- Fixes a mock implementation for `mockCreateMembershipFromInvitationTask`: was mocking the `InvitationTaskManager.createCreateMembershipFromInvitationTask` itself, but this is part of the code we actually want to test. Replaces with an implementation which mocks the underlying external `InvitationService` (db-level).
